### PR TITLE
fix(comments): fix error when using targets column

### DIFF
--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -194,6 +194,40 @@ describe("diffComments", () => {
     });
   });
 
+  test("first has columns only", () => {
+    // ARRANGE
+    const first: Comments = {
+      table1: {
+        table: undefined,
+        columns: [
+          {
+            tableName: "table1",
+            columnName: "field1",
+            comment: "field1 comment",
+          },
+        ],
+      },
+    };
+    const second: Comments = {};
+
+    // ACT
+    const comments = diffComments(first, second);
+
+    // ASSERT
+    expect(comments).toStrictEqual({
+      table1: {
+        table: undefined,
+        columns: [
+          {
+            tableName: "table1",
+            columnName: "field1",
+            comment: "field1 comment",
+          },
+        ],
+      },
+    });
+  });
+
   test("empty first", () => {
     // ARRANGE
     const first: Comments = {};

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -94,7 +94,10 @@ const diffTableComments = (
   first: TableComments,
   second?: TableComments,
 ): TableComments | undefined => {
-  const tableDiff = diffComment(first.table!, second?.table);
+  const tableDiff = first.table
+    ? diffComment(first.table!, second?.table)
+    : undefined;
+
   const commentDiffs = first.columns
     ?.map((firstColumn) => {
       // カラムが一致するものを探して比較


### PR DESCRIPTION
### Problem

I got an error when using options `targets = [”column”]` . 

```typescript
generator comments {
  provider = "prisma-db-comments-generator"
  targets  = ["column"]
}
```
The error message was: `Cannot read properties of undefined (reading 'comment')` . 

The reason error occurs: 

1.  `createComments` function generates object that has `table` key with `undefined` value. example below:

```typescript
{
    table1: {
      table: undefined,
      columns: [
        {
          tableName: "table1",
          columnName: "field1",
          comment: "field1 comment",
        },
      ],
    },
}
```

2. When comparing the different with `diffComments` , it will call `diffTableComments` .
3. The `diffTableComments` function thinks that the  `table` key always has a value.  
4. The `diffComment` function throw error because `first` argument is expected to be an object, but it is `undefined` .

### Suggested Solution

I propose to add conditional before calling `diffComment`  on `diffTableComments` function

```typescript
const tableDiff = first.table
    ? diffComment(first.table!, second?.table)
    : undefined;
```