### PR TITLE
feat: add commentRemovePatternFlags option with default global flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ COMMENT ON COLUMN "sales"."total_price" IS 'Total Price';
 | [ignorePattern](#ignorepattern) | Exclude models by database name |
 | [ignoreCommentPattern](#ignorecommentpattern) | Exclude comments by content |
 | [commentRemovePattern](#commentremovepattern) | Remove matching text from comments |
+| [commentRemovePatternFlags](#commentremovepatternflags) | Regex flags for `commentRemovePattern` (default: `g`) |
 | [commentTransformScript](#commenttransformscript) | Transform comments with a script |
 | [includeEnumInFieldComment](#includeenuminfieldcomment) | Add enum values to field comments |
 
@@ -211,6 +212,7 @@ generator comments {
 ### commentRemovePattern
 
 Specify a regular expression with `commentRemovePattern` to remove matching text from comments.
+By default, the pattern is applied globally (all occurrences are removed). See [`commentRemovePatternFlags`](#commentremovepatternflags) to change this behavior.
 
 This is useful when combining with other Prisma generators that use annotations in triple-slash comments.
 For example, [prismabox](https://github.com/m1212e/prismabox) uses annotations like `@prismabox.hide` or `@prismabox.options{ min: 10, max: 20 }` in comments. Since Prisma concatenates multiple `///` comments with `\n`, you need to include the newline in the pattern.
@@ -240,6 +242,31 @@ The following comment is generated (annotation line is removed).
 
 ```sql
 COMMENT ON COLUMN "users"."user_id" IS 'this is the user id';
+```
+
+### commentRemovePatternFlags
+
+Specify the regex flags for `commentRemovePattern` with `commentRemovePatternFlags`.
+The default is `g` (global — removes all occurrences). You can specify any combination of valid JavaScript regex flags (`g`, `i`, `m`, etc.).
+
+For example, the following removes `@internal` case-insensitively and globally.
+
+```prisma
+generator comments {
+  provider                  = "prisma-db-comments-generator"
+  commentRemovePattern      = " @internal"
+  commentRemovePatternFlags = "gi"
+}
+```
+
+To revert to the previous behavior (remove only the first occurrence), specify an empty string.
+
+```prisma
+generator comments {
+  provider                  = "prisma-db-comments-generator"
+  commentRemovePattern      = " @internal"
+  commentRemovePatternFlags = ""
+}
 ```
 
 ### commentTransformScript

--- a/src/__fixtures__/comment-remove-pattern-flags/schema.prisma
+++ b/src/__fixtures__/comment-remove-pattern-flags/schema.prisma
@@ -1,0 +1,24 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator comments {
+  provider                    = "node ./dist/generator.cjs"
+  commentRemovePattern        = " @internal"
+  commentRemovePatternFlags   = "gi"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+/// Customer table @internal
+model Customer {
+  /// Customer ID @INTERNAL
+  customerId Int    @id @map("customer_id")
+  /// Customer Name @Internal @INTERNAL
+  name       String
+
+  @@map("customers")
+}

--- a/src/__fixtures__/comment-remove-pattern/schema.prisma
+++ b/src/__fixtures__/comment-remove-pattern/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator comments {
+  provider             = "node ./dist/generator.cjs"
+  commentRemovePattern = " @internal"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+/// Customer table @internal
+model Customer {
+  /// Customer ID @internal
+  customerId Int    @id @map("customer_id")
+  /// Customer Name @internal @internal
+  name       String
+
+  @@map("customers")
+}

--- a/src/__snapshots__/generator.test.ts.snap
+++ b/src/__snapshots__/generator.test.ts.snap
@@ -134,6 +134,70 @@ COMMENT ON COLUMN "sales"."total_price" IS 'Total Price';
 "
 `;
 
+exports[`comment-remove-pattern > comments-latest.json 1`] = `
+"{
+  "customers": {
+    "table": {
+      "tableName": "customers",
+      "comment": "Customer table"
+    },
+    "columns": [
+      {
+        "tableName": "customers",
+        "columnName": "customer_id",
+        "comment": "Customer ID"
+      },
+      {
+        "tableName": "customers",
+        "columnName": "name",
+        "comment": "Customer Name"
+      }
+    ]
+  }
+}"
+`;
+
+exports[`comment-remove-pattern > migration.sql 1`] = `
+"
+-- customers comments
+COMMENT ON TABLE "customers" IS 'Customer table';
+COMMENT ON COLUMN "customers"."customer_id" IS 'Customer ID';
+COMMENT ON COLUMN "customers"."name" IS 'Customer Name';
+"
+`;
+
+exports[`comment-remove-pattern-flags > comments-latest.json 1`] = `
+"{
+  "customers": {
+    "table": {
+      "tableName": "customers",
+      "comment": "Customer table"
+    },
+    "columns": [
+      {
+        "tableName": "customers",
+        "columnName": "customer_id",
+        "comment": "Customer ID"
+      },
+      {
+        "tableName": "customers",
+        "columnName": "name",
+        "comment": "Customer Name"
+      }
+    ]
+  }
+}"
+`;
+
+exports[`comment-remove-pattern-flags > migration.sql 1`] = `
+"
+-- customers comments
+COMMENT ON TABLE "customers" IS 'Customer table';
+COMMENT ON COLUMN "customers"."customer_id" IS 'Customer ID';
+COMMENT ON COLUMN "customers"."name" IS 'Customer Name';
+"
+`;
+
 exports[`comment-transform > comments-latest.json 1`] = `
 "{
   "customers": {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -35,6 +35,7 @@ describe("readConfig", () => {
       ignorePattern: undefined,
       ignoreCommentPattern: undefined,
       commentRemovePattern: undefined,
+      commentRemovePatternFlags: "g",
       commentTransformFn: undefined,
       includeEnumInFieldComment: false,
       provider: "postgresql",
@@ -279,6 +280,7 @@ describe("readConfig", () => {
       ignorePattern: expect.any(RegExp),
       ignoreCommentPattern: expect.any(RegExp),
       commentRemovePattern: undefined,
+      commentRemovePatternFlags: "g",
       commentTransformFn: undefined,
       includeEnumInFieldComment: true,
       provider: "mysql",
@@ -304,9 +306,58 @@ describe("readConfig", () => {
     // Assert
     expect(config.commentRemovePattern).toBeInstanceOf(RegExp);
     expect(config.commentRemovePattern?.source).toBe("@Description ");
+    expect(config.commentRemovePattern?.flags).toBe("g");
     expect(
-      "@Description User table".replace(config.commentRemovePattern!, ""),
+      "@Description User @Description table".replace(
+        config.commentRemovePattern!,
+        "",
+      ),
     ).toBe("User table");
+  });
+
+  test("creates commentRemovePattern RegExp with specified flags", async () => {
+    // Arrange
+    const generator = {
+      ...baseGenerator,
+      config: {
+        commentRemovePattern: "@internal",
+        commentRemovePatternFlags: "gi",
+      },
+    };
+    const datasources = baseDatasources;
+
+    // Act
+    const config = await readConfig({ generator, datasources });
+
+    // Assert
+    expect(config.commentRemovePattern).toBeInstanceOf(RegExp);
+    expect(config.commentRemovePattern?.flags).toBe("gi");
+    expect(
+      "@internal desc @INTERNAL".replace(config.commentRemovePattern!, ""),
+    ).toBe(" desc ");
+  });
+
+  test("creates commentRemovePattern RegExp with empty flags (no global)", async () => {
+    // Arrange
+    const generator = {
+      ...baseGenerator,
+      config: {
+        commentRemovePattern: "@internal",
+        commentRemovePatternFlags: "",
+      },
+    };
+    const datasources = baseDatasources;
+
+    // Act
+    const config = await readConfig({ generator, datasources });
+
+    // Assert
+    expect(config.commentRemovePattern).toBeInstanceOf(RegExp);
+    expect(config.commentRemovePattern?.flags).toBe("");
+    // フラグなしの場合は最初の1件のみ削除
+    expect(
+      "@internal desc @internal".replace(config.commentRemovePattern!, ""),
+    ).toBe(" desc @internal");
   });
 
   test("loads commentTransformFn from commentTransformScript", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface Config {
   ignorePattern?: RegExp;
   ignoreCommentPattern?: RegExp;
   commentRemovePattern?: RegExp;
+  commentRemovePatternFlags?: string;
   commentTransformFn?: CommentTransformFn;
   includeEnumInFieldComment: boolean;
   provider: DatabaseProvider;
@@ -39,12 +40,20 @@ export const readConfig = async ({
     ignoreCommentPattern = new RegExp(generator.config.ignoreCommentPattern);
   }
 
+  const commentRemovePatternFlags =
+    typeof generator.config.commentRemovePatternFlags === "string"
+      ? generator.config.commentRemovePatternFlags
+      : "g";
+
   let commentRemovePattern;
   if (
     generator.config.commentRemovePattern &&
     typeof generator.config.commentRemovePattern === "string"
   ) {
-    commentRemovePattern = new RegExp(generator.config.commentRemovePattern);
+    commentRemovePattern = new RegExp(
+      generator.config.commentRemovePattern,
+      commentRemovePatternFlags,
+    );
   }
 
   let commentTransformFn: CommentTransformFn | undefined;
@@ -102,6 +111,7 @@ export const readConfig = async ({
     ignorePattern,
     ignoreCommentPattern,
     commentRemovePattern,
+    commentRemovePatternFlags,
     commentTransformFn,
     includeEnumInFieldComment,
     provider,

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -126,6 +126,36 @@ test("comment-transform", async () => {
   expect(commentsLatestJsonContent).toMatchSnapshot("comments-latest.json");
 });
 
+test("comment-remove-pattern", async () => {
+  // Arrange
+  const name = "comment-remove-pattern";
+
+  // Act
+  executeGenerate(name);
+
+  // Assert
+  const migrationSqlContent = readMigrationSql(name);
+  expect(migrationSqlContent).toMatchSnapshot("migration.sql");
+
+  const commentsLatestJsonContent = readCommentsLatestJson(name);
+  expect(commentsLatestJsonContent).toMatchSnapshot("comments-latest.json");
+});
+
+test("comment-remove-pattern-flags", async () => {
+  // Arrange
+  const name = "comment-remove-pattern-flags";
+
+  // Act
+  executeGenerate(name);
+
+  // Assert
+  const migrationSqlContent = readMigrationSql(name);
+  expect(migrationSqlContent).toMatchSnapshot("migration.sql");
+
+  const commentsLatestJsonContent = readCommentsLatestJson(name);
+  expect(commentsLatestJsonContent).toMatchSnapshot("comments-latest.json");
+});
+
 test("multi-file-schema", async () => {
   // Arrange
   const name = "multi-file-schema";


### PR DESCRIPTION
Add `commentRemovePatternFlags` option to control regex flags for `commentRemovePattern`. The default is `g` (global), so all occurrences are removed per comment instead of just the first match.