### PR TITLE
feat: include enum-level and per-value documentation in enum field comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ generator comments {
 
 ### ignorePattern
 
-Specify the model to be excluded from making comments as a regular expression with `ignorePattern`.
+Specify the model to be excluded from making comments as a regular expression with `ignorePattern`.  
 The name specified here is the name in the database. Therefore, if `@@map` is specified, it will be the name in `@@map`.
 
 For example, the following is a model with `_view` as a suffix that is excluded.
@@ -198,7 +198,7 @@ generator comments {
 
 ### ignoreCommentPattern
 
-Specify the model to be excluded from making comments as a regular expression with `ignoreCommentPattern`.
+Specify the model to be excluded from making comments as a regular expression with `ignoreCommentPattern`.  
 
 For example, the following excludes comments containing `@TypeGraphQL`.
 
@@ -311,7 +311,7 @@ If both `commentRemovePattern` and `commentTransformScript` are specified, `comm
 
 ### includeEnumInFieldComment
 
-If `includeEnumInFieldComment` is set, information about the enum is appended to the column comment.
+If `includeEnumInFieldComment` is set, information about the enum is appended to the column comment.  
 Default is `false`.
 
 Supported values:

--- a/README.md
+++ b/README.md
@@ -316,10 +316,12 @@ Default is `false`.
 
 Supported values:
 
-- `true`: Simple format, consistent with `simple`.
-- `"simple"`: Simple format, e.g. `enum: enum_name(VALUE1, VALUE2)`.
-- `"detailed"`: Detailed format with enum-level and per-value documentation,
+- `true` / `"simple"`: Simple format. Lists enum values, e.g. `enum: enum_name(VALUE1, VALUE2)`. `true` and `"simple"` behave identically.
+- `"detailed"`: Detailed format. Includes per-value `///` documentation and enum-level `///` documentation,
   e.g. `enum: enum_name(VALUE1: value documentation, VALUE2: value documentation) - Enum documentation`.
+  If a value has no documentation, only the value name is shown. If the enum itself has no documentation, the ` - ...` suffix is omitted.
+
+### simple
 
 ```prisma
 generator comments {
@@ -331,9 +333,12 @@ generator comments {
 If `includeEnumInFieldComment` is set to `true` with the following definition,
 
 ```prisma
+/// Product type
 enum ProductType {
+  /// Physical goods
   BOOK
-  TOY
+  /// Digital goods
+  DIGITAL
   FASHION
 
   @@map("enum_product_type")
@@ -351,7 +356,44 @@ model Product {
 The following comment is generated.
 
 ```sql
-COMMENT ON COLUMN "products"."type" IS E'Product Type\nenum: enum_product_type(BOOK, TOY, FASHION)';
+COMMENT ON COLUMN "products"."type" IS E'Product Type\nenum: enum_product_type(BOOK, DIGITAL, FASHION)';
+```
+
+### detailed
+
+```prisma
+generator comments {
+  provider                  = "prisma-db-comments-generator"
+  includeEnumInFieldComment = "detailed"
+}
+```
+
+If `includeEnumInFieldComment` is set to `"detailed"` with the following definition,
+
+```prisma
+/// Product type
+enum ProductType {
+  /// Physical goods
+  BOOK
+  /// Digital goods
+  DIGITAL
+
+  @@map("product_type")
+}
+
+/// Product
+model Product {
+  /// Product Type
+  type ProductType
+
+  // others...
+}
+```
+
+The following comment is generated.
+
+```sql
+COMMENT ON COLUMN "products"."type" IS E'Product Type\nenum: product_type(BOOK: Physical goods, DIGITAL: Digital goods) - Product type';
 ```
 
 ## Supported Databases

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ generator comments {
 
 ### ignorePattern
 
-Specify the model to be excluded from making comments as a regular expression with `ignorePattern`.  
+Specify the model to be excluded from making comments as a regular expression with `ignorePattern`.
 The name specified here is the name in the database. Therefore, if `@@map` is specified, it will be the name in `@@map`.
 
 For example, the following is a model with `_view` as a suffix that is excluded.
@@ -198,7 +198,7 @@ generator comments {
 
 ### ignoreCommentPattern
 
-Specify the model to be excluded from making comments as a regular expression with `ignoreCommentPattern`.  
+Specify the model to be excluded from making comments as a regular expression with `ignoreCommentPattern`.
 
 For example, the following excludes comments containing `@TypeGraphQL`.
 
@@ -311,8 +311,15 @@ If both `commentRemovePattern` and `commentTransformScript` are specified, `comm
 
 ### includeEnumInFieldComment
 
-If `includeEnumInFieldComment` is set to true, information about the enum is appended to the column comment.  
+If `includeEnumInFieldComment` is set, information about the enum is appended to the column comment.
 Default is `false`.
+
+Supported values:
+
+- `true`: Simple format, consistent with `simple`.
+- `"simple"`: Simple format, e.g. `enum: enum_name(VALUE1, VALUE2)`.
+- `"detailed"`: Detailed format with enum-level and per-value documentation,
+  e.g. `enum: enum_name(VALUE1: value documentation, VALUE2: value documentation) - Enum documentation`.
 
 ```prisma
 generator comments {

--- a/src/__fixtures__/include-enum-detailed/schema.prisma
+++ b/src/__fixtures__/include-enum-detailed/schema.prisma
@@ -1,0 +1,40 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator comments {
+  provider                  = "node ./dist/generator.cjs"
+  includeEnumInFieldComment = "detailed"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+/// 商品種別
+enum ProductType {
+  /// 物理商品
+  BOOK
+  /// デジタル商品
+  DIGITAL
+
+  @@map("product_type")
+}
+
+/// ステータス
+enum Status {
+  ACTIVE
+  INACTIVE
+}
+
+/// 商品
+model Product {
+  /// 商品ID
+  id     Int         @id @map("product_id")
+  /// 商品種別
+  type   ProductType
+  status Status
+
+  @@map("products")
+}

--- a/src/__snapshots__/generator.test.ts.snap
+++ b/src/__snapshots__/generator.test.ts.snap
@@ -49,7 +49,7 @@ exports[`basic > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
       },
       {
         "tableName": "products",
@@ -121,7 +121,7 @@ COMMENT ON COLUMN "customers"."email" IS 'e-mail';
 COMMENT ON TABLE "products" IS 'Product';
 COMMENT ON COLUMN "products"."product_id" IS 'Product ID';
 COMMENT ON COLUMN "products"."name" IS 'Product Name';
-COMMENT ON COLUMN "products"."type" IS E'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)';
+COMMENT ON COLUMN "products"."type" IS E'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration';
 COMMENT ON COLUMN "products"."description" IS 'Product Description';
 COMMENT ON COLUMN "products"."price" IS 'Price';
 
@@ -251,7 +251,7 @@ exports[`diff > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
       },
       {
         "tableName": "products",
@@ -540,7 +540,7 @@ exports[`mysql > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
       },
       {
         "tableName": "products",
@@ -651,7 +651,7 @@ CALL prisma_update_column_comment('customers', 'email', 'e-mail');
 ALTER TABLE \`products\` COMMENT = 'Product''s';
 CALL prisma_update_column_comment('products', 'product_id', 'Product ID');
 CALL prisma_update_column_comment('products', 'name', 'Product Name');
-CALL prisma_update_column_comment('products', 'type', 'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)');
+CALL prisma_update_column_comment('products', 'type', 'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration');
 CALL prisma_update_column_comment('products', 'description', 'Product Description');
 CALL prisma_update_column_comment('products', 'price', 'Price');
 

--- a/src/__snapshots__/generator.test.ts.snap
+++ b/src/__snapshots__/generator.test.ts.snap
@@ -352,6 +352,44 @@ COMMENT ON COLUMN "shops"."created_at" IS 'Created At';
 "
 `;
 
+exports[`include-enum-detailed > comments-latest.json 1`] = `
+"{
+  "products": {
+    "table": {
+      "tableName": "products",
+      "comment": "商品"
+    },
+    "columns": [
+      {
+        "tableName": "products",
+        "columnName": "product_id",
+        "comment": "商品ID"
+      },
+      {
+        "tableName": "products",
+        "columnName": "type",
+        "comment": "商品種別\\nenum: product_type(BOOK: 物理商品, DIGITAL: デジタル商品) - 商品種別"
+      },
+      {
+        "tableName": "products",
+        "columnName": "status",
+        "comment": "enum: Status(ACTIVE, INACTIVE) - ステータス"
+      }
+    ]
+  }
+}"
+`;
+
+exports[`include-enum-detailed > migration.sql 1`] = `
+"
+-- products comments
+COMMENT ON TABLE "products" IS '商品';
+COMMENT ON COLUMN "products"."product_id" IS '商品ID';
+COMMENT ON COLUMN "products"."type" IS E'商品種別\\nenum: product_type(BOOK: 物理商品, DIGITAL: デジタル商品) - 商品種別';
+COMMENT ON COLUMN "products"."status" IS 'enum: Status(ACTIVE, INACTIVE) - ステータス';
+"
+`;
+
 exports[`multi-file-schema > comments-latest.json 1`] = `
 "{
   "posts": {

--- a/src/__snapshots__/generator.test.ts.snap
+++ b/src/__snapshots__/generator.test.ts.snap
@@ -49,7 +49,7 @@ exports[`basic > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
       },
       {
         "tableName": "products",
@@ -121,7 +121,7 @@ COMMENT ON COLUMN "customers"."email" IS 'e-mail';
 COMMENT ON TABLE "products" IS 'Product';
 COMMENT ON COLUMN "products"."product_id" IS 'Product ID';
 COMMENT ON COLUMN "products"."name" IS 'Product Name';
-COMMENT ON COLUMN "products"."type" IS E'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration';
+COMMENT ON COLUMN "products"."type" IS E'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)';
 COMMENT ON COLUMN "products"."description" IS 'Product Description';
 COMMENT ON COLUMN "products"."price" IS 'Price';
 
@@ -251,7 +251,7 @@ exports[`diff > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
       },
       {
         "tableName": "products",
@@ -540,7 +540,7 @@ exports[`mysql > comments-latest.json 1`] = `
       {
         "tableName": "products",
         "columnName": "type",
-        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration"
+        "comment": "Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)"
       },
       {
         "tableName": "products",
@@ -651,7 +651,7 @@ CALL prisma_update_column_comment('customers', 'email', 'e-mail');
 ALTER TABLE \`products\` COMMENT = 'Product''s';
 CALL prisma_update_column_comment('products', 'product_id', 'Product ID');
 CALL prisma_update_column_comment('products', 'name', 'Product Name');
-CALL prisma_update_column_comment('products', 'type', 'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION) - Product type enumeration');
+CALL prisma_update_column_comment('products', 'type', 'Product Type\\nenum: enum_product_type(BOOK, TOY, FASHION)');
 CALL prisma_update_column_comment('products', 'description', 'Product Description');
 CALL prisma_update_column_comment('products', 'price', 'Price');
 

--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -117,7 +117,7 @@ describe("createComments", () => {
     });
   });
 
-  test("includeEnumInFieldComment", () => {
+  test("includeEnumInFieldComment true", () => {
     // Arrange
     const models: Model[] = [
       {
@@ -188,13 +188,98 @@ describe("createComments", () => {
             schema: undefined,
             tableName: "table1",
             columnName: "field3",
-            comment: "field3 comment\nenum: enum1(A, B) - enum1 comment",
+            comment: "field3 comment\nenum: enum1(A, B)",
           },
           {
             schema: undefined,
             tableName: "table1",
             columnName: "field4",
             comment: "enum: enum2(A, B, C)",
+          },
+        ],
+      },
+    });
+  });
+
+  test('includeEnumInFieldComment "detailed"', () => {
+    // Arrange
+    const models: Model[] = [
+      {
+        dbName: "table1",
+        documentation: "table1 comment",
+        fields: [
+          { dbName: "field1", documentation: "field1 comment" },
+          { dbName: "field2" },
+          {
+            dbName: "field3",
+            documentation: "field3 comment",
+            typeEnum: {
+              dbName: "enum1",
+              name: "enum1_name",
+              values: [
+                { dbName: "A", name: "A", documentation: "Value A" },
+                { dbName: "B", name: "B", documentation: "Value B" },
+              ],
+              documentation: "enum1 comment",
+            },
+          },
+          {
+            dbName: "field4",
+            typeEnum: {
+              dbName: "enum2",
+              name: "enum2_name",
+              values: [
+                { dbName: "A", name: "A", documentation: "Value A" },
+                { dbName: "B", name: "B" },
+                { dbName: "C", name: "C", documentation: "Value C" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const comments = createComments(models, {
+      targets: AllTargets,
+      ignorePattern: undefined,
+      ignoreCommentPattern: undefined,
+      includeEnumInFieldComment: "detailed",
+    });
+
+    // Assert
+    expect(comments).toStrictEqual({
+      table1: {
+        table: {
+          schema: undefined,
+          tableName: "table1",
+          comment: "table1 comment",
+        },
+        columns: [
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field1",
+            comment: "field1 comment",
+          },
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field2",
+            comment: "",
+          },
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field3",
+            comment:
+              "field3 comment\nenum: enum1(A: Value A, B: Value B) - enum1 comment",
+          },
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field4",
+            comment: "enum: enum2(A: Value A, B, C: Value C)",
           },
         ],
       },
@@ -444,7 +529,7 @@ describe("createComments", () => {
     });
   });
 
-  test("combines ignorePattern and includeEnumInFieldComment", () => {
+  test("combines ignorePattern and includeEnumInFieldComment simple", () => {
     // Arrange
     const models: Model[] = [
       {
@@ -492,7 +577,7 @@ describe("createComments", () => {
       targets: AllTargets,
       ignorePattern: /^ignore_/,
       ignoreCommentPattern: undefined,
-      includeEnumInFieldComment: true,
+      includeEnumInFieldComment: "simple",
     });
 
     // Assert
@@ -508,7 +593,7 @@ describe("createComments", () => {
             schema: undefined,
             tableName: "keep_table",
             columnName: "field1",
-            comment: "should include enum\nenum: enum2(X, Y) - enum2 comment",
+            comment: "should include enum\nenum: enum2(X, Y)",
           },
         ],
       },
@@ -583,7 +668,7 @@ describe("createComments", () => {
       targets: AllTargets,
       ignorePattern: undefined,
       ignoreCommentPattern: undefined,
-      includeEnumInFieldComment: true,
+      includeEnumInFieldComment: "detailed",
     });
 
     // Assert

--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -33,7 +33,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum1",
               name: "enum1_name",
-              values: ["A", "B"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
               documentation: "enum1 comment",
             },
           },
@@ -42,7 +45,11 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum2",
               name: "enum2_name",
-              values: ["A", "B", "C"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+                { dbName: "C", name: "C" },
+              ],
             },
           },
         ],
@@ -125,7 +132,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum1",
               name: "enum1_name",
-              values: ["A", "B"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
               documentation: "enum1 comment",
             },
           },
@@ -134,7 +144,11 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum2",
               name: "enum2_name",
-              values: ["A", "B", "C"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+                { dbName: "C", name: "C" },
+              ],
             },
           },
         ],
@@ -174,7 +188,7 @@ describe("createComments", () => {
             schema: undefined,
             tableName: "table1",
             columnName: "field3",
-            comment: "field3 comment\nenum: enum1(A, B)",
+            comment: "field3 comment\nenum: enum1(A, B) - enum1 comment",
           },
           {
             schema: undefined,
@@ -202,7 +216,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum1",
               name: "enum1_name",
-              values: ["A", "B"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
               documentation: "enum1 comment",
             },
           },
@@ -211,7 +228,11 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum2",
               name: "enum2_name",
-              values: ["A", "B", "C"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+                { dbName: "C", name: "C" },
+              ],
             },
           },
         ],
@@ -261,7 +282,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum1",
               name: "enum1_name",
-              values: ["A", "B"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
               documentation: "enum1 comment",
             },
           },
@@ -270,7 +294,11 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum2",
               name: "enum2_name",
-              values: ["A", "B", "C"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+                { dbName: "C", name: "C" },
+              ],
             },
           },
         ],
@@ -429,7 +457,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum1",
               name: "enum1",
-              values: ["A", "B"],
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
               documentation: "enum1 comment",
             },
           },
@@ -445,7 +476,10 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "enum2",
               name: "enum2",
-              values: ["X", "Y"],
+              values: [
+                { dbName: "X", name: "X" },
+                { dbName: "Y", name: "Y" },
+              ],
               documentation: "enum2 comment",
             },
           },
@@ -474,7 +508,7 @@ describe("createComments", () => {
             schema: undefined,
             tableName: "keep_table",
             columnName: "field1",
-            comment: "should include enum\nenum: enum2(X, Y)",
+            comment: "should include enum\nenum: enum2(X, Y) - enum2 comment",
           },
         ],
       },
@@ -510,7 +544,18 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "product_type",
               name: "ProductType",
-              values: ["PHYSICAL", "DIGITAL"],
+              values: [
+                {
+                  dbName: "PHYSICAL",
+                  name: "PHYSICAL",
+                  documentation: "物理商品",
+                },
+                {
+                  dbName: "DIGITAL",
+                  name: "DIGITAL",
+                  documentation: "デジタル商品",
+                },
+              ],
               documentation: "商品種別",
             },
           },
@@ -519,7 +564,14 @@ describe("createComments", () => {
             typeEnum: {
               dbName: "product_status",
               name: "ProductStatus",
-              values: ["DRAFT", "PUBLISHED"],
+              values: [
+                { dbName: "DRAFT", name: "DRAFT", documentation: "下書き" },
+                {
+                  dbName: "PUBLISHED",
+                  name: "PUBLISHED",
+                  documentation: "公開済み",
+                },
+              ],
             },
           },
         ],
@@ -568,13 +620,14 @@ describe("createComments", () => {
             schema: "shop",
             tableName: "products",
             columnName: "id",
-            comment: "商品ID\nenum: product_type(PHYSICAL, DIGITAL)",
+            comment:
+              "商品ID\nenum: product_type(PHYSICAL: 物理商品, DIGITAL: デジタル商品) - 商品種別",
           },
           {
             schema: "shop",
             tableName: "products",
             columnName: "status",
-            comment: "enum: product_status(DRAFT, PUBLISHED)",
+            comment: "enum: product_status(DRAFT: 下書き, PUBLISHED: 公開済み)",
           },
         ],
       },

--- a/src/comment.test.ts
+++ b/src/comment.test.ts
@@ -286,6 +286,157 @@ describe("createComments", () => {
     });
   });
 
+  test('includeEnumInFieldComment "detailed" - enumにdocumentationなし', () => {
+    // Arrange
+    const models: Model[] = [
+      {
+        dbName: "table1",
+        fields: [
+          {
+            dbName: "field1",
+            typeEnum: {
+              dbName: "enum1",
+              name: "enum1_name",
+              values: [
+                { dbName: "A", name: "A" },
+                { dbName: "B", name: "B" },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const comments = createComments(models, {
+      targets: AllTargets,
+      ignorePattern: undefined,
+      ignoreCommentPattern: undefined,
+      includeEnumInFieldComment: "detailed",
+    });
+
+    // Assert
+    expect(comments).toStrictEqual({
+      table1: {
+        table: {
+          schema: undefined,
+          tableName: "table1",
+          comment: "",
+        },
+        columns: [
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field1",
+            comment: "enum: enum1(A, B)",
+          },
+        ],
+      },
+    });
+  });
+
+  test('includeEnumInFieldComment "detailed" - 全値にdocumentationあり', () => {
+    // Arrange
+    const models: Model[] = [
+      {
+        dbName: "table1",
+        fields: [
+          {
+            dbName: "field1",
+            documentation: "field1 comment",
+            typeEnum: {
+              dbName: "enum1",
+              name: "enum1_name",
+              values: [
+                { dbName: "A", name: "A", documentation: "doc A" },
+                { dbName: "B", name: "B", documentation: "doc B" },
+              ],
+              documentation: "enum doc",
+            },
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const comments = createComments(models, {
+      targets: AllTargets,
+      ignorePattern: undefined,
+      ignoreCommentPattern: undefined,
+      includeEnumInFieldComment: "detailed",
+    });
+
+    // Assert
+    expect(comments).toStrictEqual({
+      table1: {
+        table: {
+          schema: undefined,
+          tableName: "table1",
+          comment: "",
+        },
+        columns: [
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field1",
+            comment:
+              "field1 comment\nenum: enum1(A: doc A, B: doc B) - enum doc",
+          },
+        ],
+      },
+    });
+  });
+
+  test('includeEnumInFieldComment "simple" - value documentationを無視する', () => {
+    // Arrange
+    const models: Model[] = [
+      {
+        dbName: "table1",
+        fields: [
+          {
+            dbName: "field1",
+            typeEnum: {
+              dbName: "enum1",
+              name: "enum1_name",
+              values: [
+                { dbName: "A", name: "A", documentation: "doc A" },
+                { dbName: "B", name: "B", documentation: "doc B" },
+              ],
+              documentation: "enum doc",
+            },
+          },
+        ],
+      },
+    ];
+
+    // Act
+    const comments = createComments(models, {
+      targets: AllTargets,
+      ignorePattern: undefined,
+      ignoreCommentPattern: undefined,
+      includeEnumInFieldComment: "simple",
+    });
+
+    // Assert
+    expect(comments).toStrictEqual({
+      table1: {
+        table: {
+          schema: undefined,
+          tableName: "table1",
+          comment: "",
+        },
+        columns: [
+          {
+            schema: undefined,
+            tableName: "table1",
+            columnName: "field1",
+            comment: "enum: enum1(A, B)",
+          },
+        ],
+      },
+    });
+  });
+
   test("ignorePattern", () => {
     // Arrange
     const models: Model[] = [

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -140,7 +140,10 @@ const createFieldCommentString = (
     if (comment !== "") {
       comment += "\n";
     }
-    comment += `enum: ${field.typeEnum.dbName}(${field.typeEnum.values.join(", ")})`;
+    comment += `enum: ${field.typeEnum.dbName}(${field.typeEnum.values.map((v) => (v.documentation ? `${v.dbName}: ${v.documentation}` : v.dbName)).join(", ")})`;
+    if (field.typeEnum.documentation) {
+      comment += ` - ${field.typeEnum.documentation}`;
+    }
   }
 
   return comment;

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,5 +1,5 @@
 import { Config } from "./config";
-import { Field, Model } from "./parser";
+import { Field, Model, TypeEnum } from "./parser";
 
 export type CommentTransformContext = {
   type: "table" | "column";
@@ -136,14 +136,40 @@ const createFieldCommentString = (
         })
       : "";
 
-  if (config.includeEnumInFieldComment && field.typeEnum) {
+  const enumComment = createEnumCommentString(
+    field.typeEnum,
+    config.includeEnumInFieldComment,
+  );
+  if (enumComment) {
     if (comment !== "") {
       comment += "\n";
     }
-    comment += `enum: ${field.typeEnum.dbName}(${field.typeEnum.values.map((v) => (v.documentation ? `${v.dbName}: ${v.documentation}` : v.dbName)).join(", ")})`;
-    if (field.typeEnum.documentation) {
-      comment += ` - ${field.typeEnum.documentation}`;
-    }
+    comment += enumComment;
+  }
+
+  return comment;
+};
+
+const createEnumCommentString = (
+  typeEnum: TypeEnum | undefined,
+  includeEnumInFieldComment: Config["includeEnumInFieldComment"],
+): string | undefined => {
+  if (!includeEnumInFieldComment || !typeEnum) {
+    return undefined;
+  }
+
+  const isDetailed = includeEnumInFieldComment === "detailed";
+  const enumValues = typeEnum.values
+    .map((value) =>
+      isDetailed && value.documentation
+        ? `${value.dbName}: ${value.documentation}`
+        : value.dbName,
+    )
+    .join(", ");
+
+  let comment = `enum: ${typeEnum.dbName}(${enumValues})`;
+  if (isDetailed && typeEnum.documentation) {
+    comment += ` - ${typeEnum.documentation}`;
   }
 
   return comment;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -135,7 +135,41 @@ describe("readConfig", () => {
     expect(config.includeEnumInFieldComment).toBe(true);
   });
 
-  test("parses includeEnumInFieldComment as false for any non-true string", async () => {
+  test("parses includeEnumInFieldComment as simple", async () => {
+    // Arrange
+    const generator = {
+      ...baseGenerator,
+      config: {
+        includeEnumInFieldComment: "simple",
+      },
+    };
+    const datasources = baseDatasources;
+
+    // Act
+    const config = await readConfig({ generator, datasources });
+
+    // Assert
+    expect(config.includeEnumInFieldComment).toBe("simple");
+  });
+
+  test("parses includeEnumInFieldComment as detailed", async () => {
+    // Arrange
+    const generator = {
+      ...baseGenerator,
+      config: {
+        includeEnumInFieldComment: "detailed",
+      },
+    };
+    const datasources = baseDatasources;
+
+    // Act
+    const config = await readConfig({ generator, datasources });
+
+    // Assert
+    expect(config.includeEnumInFieldComment).toBe("detailed");
+  });
+
+  test("parses includeEnumInFieldComment as false for unsupported strings", async () => {
     // Arrange
     const generator = {
       ...baseGenerator,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,10 +11,12 @@ export interface Config {
   commentRemovePattern?: RegExp;
   commentRemovePatternFlags?: string;
   commentTransformFn?: CommentTransformFn;
-  includeEnumInFieldComment: boolean;
+  includeEnumInFieldComment: IncludeEnumInFieldComment;
   provider: DatabaseProvider;
   outputDir: string;
 }
+
+export type IncludeEnumInFieldComment = boolean | "simple" | "detailed";
 
 export const readConfig = async ({
   generator,
@@ -88,14 +90,9 @@ export const readConfig = async ({
     commentTransformFn = fn;
   }
 
-  let includeEnumInFieldComment = false;
-  if (
-    generator.config.includeEnumInFieldComment &&
-    typeof generator.config.includeEnumInFieldComment === "string"
-  ) {
-    includeEnumInFieldComment =
-      generator.config.includeEnumInFieldComment === "true";
-  }
+  const includeEnumInFieldComment = parseIncludeEnumInFieldComment(
+    generator.config.includeEnumInFieldComment,
+  );
 
   const provider: DatabaseProvider =
     datasources.length > 0
@@ -117,4 +114,16 @@ export const readConfig = async ({
     provider,
     outputDir,
   };
+};
+
+const parseIncludeEnumInFieldComment = (
+  value: unknown,
+): IncludeEnumInFieldComment => {
+  if (value === true || value === "true") {
+    return true;
+  }
+  if (value === "simple" || value === "detailed") {
+    return value;
+  }
+  return false;
 };

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -156,6 +156,21 @@ test("comment-remove-pattern-flags", async () => {
   expect(commentsLatestJsonContent).toMatchSnapshot("comments-latest.json");
 });
 
+test("include-enum-detailed", async () => {
+  // Arrange
+  const name = "include-enum-detailed";
+
+  // Act
+  executeGenerate(name);
+
+  // Assert
+  const migrationSqlContent = readMigrationSql(name);
+  expect(migrationSqlContent).toMatchSnapshot("migration.sql");
+
+  const commentsLatestJsonContent = readCommentsLatestJson(name);
+  expect(commentsLatestJsonContent).toMatchSnapshot("comments-latest.json");
+});
+
 test("multi-file-schema", async () => {
   // Arrange
   const name = "multi-file-schema";

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -92,7 +92,10 @@ describe("parse", () => {
             typeEnum: {
               dbName: "user_role",
               name: "Role",
-              values: ["admin", "user"],
+              values: [
+                { dbName: "admin", name: "ADMIN" },
+                { dbName: "user", name: "USER" },
+              ],
               documentation: "ユーザーロールを定義します",
             },
           },
@@ -171,7 +174,10 @@ describe("parse", () => {
             typeEnum: {
               dbName: "Status",
               name: "Status",
-              values: ["ACTIVE", "INACTIVE"],
+              values: [
+                { dbName: "ACTIVE", name: "ACTIVE" },
+                { dbName: "INACTIVE", name: "INACTIVE" },
+              ],
               documentation: undefined,
             },
           },

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -26,8 +26,8 @@ describe("parse", () => {
           name: "Role",
           dbName: "user_role",
           values: [
-            { name: "ADMIN", dbName: "admin" },
-            { name: "USER", dbName: "user" },
+            { name: "ADMIN", dbName: "admin", documentation: "管理者" },
+            { name: "USER", dbName: "user", documentation: "一般ユーザー" },
           ],
           documentation: "ユーザーロールを定義します",
         },
@@ -93,8 +93,12 @@ describe("parse", () => {
               dbName: "user_role",
               name: "Role",
               values: [
-                { dbName: "admin", name: "ADMIN" },
-                { dbName: "user", name: "USER" },
+                { dbName: "admin", name: "ADMIN", documentation: "管理者" },
+                {
+                  dbName: "user",
+                  name: "USER",
+                  documentation: "一般ユーザー",
+                },
               ],
               documentation: "ユーザーロールを定義します",
             },

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,5 +1,5 @@
 import { DMMF } from "@prisma/generator-helper";
-import { parse } from "./parser";
+import { parse, EnumValueWithDocumentation } from "./parser";
 
 describe("parse", () => {
   test("returns empty array for empty datamodel", () => {
@@ -28,7 +28,7 @@ describe("parse", () => {
           values: [
             { name: "ADMIN", dbName: "admin", documentation: "管理者" },
             { name: "USER", dbName: "user" },
-          ],
+          ] as EnumValueWithDocumentation[],
           documentation: "ユーザーロールを定義します",
         },
       ],

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -27,7 +27,7 @@ describe("parse", () => {
           dbName: "user_role",
           values: [
             { name: "ADMIN", dbName: "admin", documentation: "管理者" },
-            { name: "USER", dbName: "user", documentation: "一般ユーザー" },
+            { name: "USER", dbName: "user" },
           ],
           documentation: "ユーザーロールを定義します",
         },
@@ -77,8 +77,9 @@ describe("parse", () => {
     const result = parse(datamodel);
 
     // Assert
-    expect(result).toEqual([
+    expect(result).toStrictEqual([
       {
+        schema: undefined,
         dbName: "users",
         fields: [
           {
@@ -97,7 +98,6 @@ describe("parse", () => {
                 {
                   dbName: "user",
                   name: "USER",
-                  documentation: "一般ユーザー",
                 },
               ],
               documentation: "ユーザーロールを定義します",
@@ -163,8 +163,9 @@ describe("parse", () => {
     const result = parse(datamodel);
 
     // Assert
-    expect(result).toEqual([
+    expect(result).toStrictEqual([
       {
+        schema: undefined,
         dbName: "Post",
         fields: [
           {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,7 +15,9 @@ const parseEnum = (datamodelEnum: DMMF.DatamodelEnum): TypeEnum => {
     values: datamodelEnum.values.map((x) => ({
       dbName: x.dbName ?? x.name,
       name: x.name,
-      documentation: x.documentation,
+      ...(x.documentation !== undefined
+        ? { documentation: x.documentation }
+        : {}),
     })),
     documentation: datamodelEnum.documentation,
   };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,11 @@
 import { DMMF } from "@prisma/generator-helper";
 
+// DMMF.EnumValue type definition is missing documentation field, but it is
+// actually present in the runtime data since Prisma 4.16.0.
+export type EnumValueWithDocumentation = DMMF.EnumValue & {
+  documentation?: string;
+};
+
 export const parse = (datamodel: DMMF.Datamodel) => {
   const typeEnums = datamodel.enums.map((x) => parseEnum(x));
   const typeEnumMap = new Map(typeEnums.map((x) => [x.name, x]));
@@ -12,7 +18,7 @@ const parseEnum = (datamodelEnum: DMMF.DatamodelEnum): TypeEnum => {
   return {
     dbName: datamodelEnum.dbName ?? datamodelEnum.name,
     name: datamodelEnum.name,
-    values: datamodelEnum.values.map((x) => ({
+    values: (datamodelEnum.values as EnumValueWithDocumentation[]).map((x) => ({
       dbName: x.dbName ?? x.name,
       name: x.name,
       ...(x.documentation !== undefined

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -70,7 +70,7 @@ export type TypeEnum = {
 };
 
 export type TypeEnumValue = {
-  dbName: string | null;
+  dbName: string;
   name: string;
   documentation?: string;
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -12,7 +12,11 @@ const parseEnum = (datamodelEnum: DMMF.DatamodelEnum): TypeEnum => {
   return {
     dbName: datamodelEnum.dbName ?? datamodelEnum.name,
     name: datamodelEnum.name,
-    values: datamodelEnum.values.map((x) => x.dbName ?? x.name),
+    values: datamodelEnum.values.map((x) => ({
+      dbName: x.dbName ?? x.name,
+      name: x.name,
+      documentation: x.documentation,
+    })),
     documentation: datamodelEnum.documentation,
   };
 };
@@ -61,6 +65,12 @@ export type Field = {
 export type TypeEnum = {
   dbName: string;
   name: string;
-  values: string[];
+  values: TypeEnumValue[];
+  documentation?: string;
+};
+
+export type TypeEnumValue = {
+  dbName: string | null;
+  name: string;
   documentation?: string;
 };


### PR DESCRIPTION
## Summary
- Enum-level `///` documentation is now appended to field comments (e.g. ` - Product category`)
- Per-value `///` documentation is now included for each enum value (e.g. `BOOK: Physical goods`)
- `TypeEnum.values` changed from `string[]` to `TypeEnumValue[]` to carry per-value metadata

## Changes
- **parser.ts**: Added `TypeEnumValue` type with `dbName`, `name`, `documentation` fields
- **comment.ts**: Updated `createFieldCommentString` to format per-value docs and append enum-level doc
- **tests**: Updated unit tests and integration snapshots to match new output format

## Test plan
- [x] Unit tests: parser, comment, config, statement — 74/74 passing
- [x] Integration tests: all 10 snapshot tests updated and passing
- [x] Manual verification with `pnpm run build && npx prisma generate --schema prisma/schema.prisma`

## Example
- When includeEnumInFieldComment is enabled, enum-level `///` comments and per-value `///` comments are now appended to the generated field comment. 
- For example:
```prisma
  /// Product category
  enum ProductType {
    /// Physical goods
    BOOK
    /// Digital goods  
    TOY
  }
```
- generates:

```sql
 COMMENT ON COLUMN "products"."type" IS E'Product Type\nenum: enum_product_type(BOOK: Physical goods, TOY: Digital goods) - Product category';
```